### PR TITLE
feat: Modernize build with Scala 3 cross-compilation and JDK 17

### DIFF
--- a/.github/clean-up.sh
+++ b/.github/clean-up.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-rm -rf "$HOME/.ivy2/local"                                                        || true
-find $HOME/.ivy2/cache                       -name "ivydata-*.properties" -delete || true
-find $HOME/.cache/coursier/v1                -name "ivydata-*.properties" -delete || true
-find $HOME/.sbt                              -name "*.lock"               -delete || true

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -7,7 +7,7 @@ jobs:
   bump-version:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         persist-credentials: false
@@ -30,7 +30,7 @@ jobs:
           --grep='^revert:' \
           --grep='^chore:' | awk 'END{print NR}')
         echo "steps.changes.outputs.count = $COUNT"
-        echo "::set-output name=count::$COUNT"
+        echo "count=$COUNT" >> "$GITHUB_OUTPUT"
     - name: Bump version and push tag
       id: tag_version
       uses: mathieudutour/github-tag-action@v6.2
@@ -39,11 +39,11 @@ jobs:
         default_bump: patch
       if: steps.changes.outputs.count > 0
     - name: Create a GitHub release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      uses: softprops/action-gh-release@v2
       with:
         tag_name: ${{ steps.tag_version.outputs.new_tag }}
-        release_name: Release ${{ steps.tag_version.outputs.new_tag }}
+        name: Release ${{ steps.tag_version.outputs.new_tag }}
         body: ${{ steps.tag_version.outputs.changelog }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       if: steps.changes.outputs.count > 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,13 @@ jobs:
       JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
       JVM_OPTS:  -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
       - run: sbt -v lint
@@ -47,8 +47,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jdk: [ 11, 17, 19 ]
-        scala: [ 2.13.18 ]
+        jdk: [ 17, 21 ]
+        scala: [ 2.13.18, 3.3.7 ]
     runs-on: ubuntu-latest
     needs: lint
     env:
@@ -57,14 +57,19 @@ jobs:
       AWS_REGION: ap-northeast-1
       TEST_TIME_FACTOR: 3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.jdk }}
           cache: 'sbt'
       - uses: sbt/setup-sbt@v1
       - name: sbt test
-        run: sbt -v ++${{ matrix.scala }} test
+        run: |
+          if [[ "${{ matrix.scala }}" == 3.* ]]; then
+            sbt -v ++${{ matrix.scala }} core/test
+          else
+            sbt -v ++${{ matrix.scala }} test
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Configure Sonatype credentials
       run: |
         mkdir -p ~/.sbt/1.0
-        printf 'realm=Sonatype Nexus Repository Manager\nhost=central.sonatype.com\nuser=%s\npassword=%s\n' \
+        printf 'host=central.sonatype.com\nuser=%s\npassword=%s\n' \
           "$SONATYPE_USERNAME" "$SONATYPE_PASSWORD" > ~/.sbt/1.0/sonatype_credentials
     - name: Configure GPG agent for loopback pinentry
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,22 +9,33 @@ jobs:
     env:
       JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
       JVM_OPTS:  -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+      SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '17'
         cache: 'sbt'
     - uses: sbt/setup-sbt@v1
-    - uses: olafurpg/setup-gpg@v3
+    - name: Configure Sonatype credentials
+      run: |
+        mkdir -p ~/.sbt/1.0
+        printf 'realm=Sonatype Nexus Repository Manager\nhost=central.sonatype.com\nuser=%s\npassword=%s\n' \
+          "$SONATYPE_USERNAME" "$SONATYPE_PASSWORD" > ~/.sbt/1.0/sonatype_credentials
+    - name: Configure GPG agent for loopback pinentry
+      run: |
+        mkdir -p ~/.gnupg
+        chmod 700 ~/.gnupg
+        echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+        echo "use-agent" >> ~/.gnupg/gpg.conf
+        echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
+        chmod 600 ~/.gnupg/gpg.conf ~/.gnupg/gpg-agent.conf
+        gpg-agent --daemon || true
     - run: sbt -v ci-release
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
-        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-        SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-    - name: clean up
-      run: "${GITHUB_WORKSPACE}/.github/clean-up.sh"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Configure Sonatype credentials
       run: |
         mkdir -p ~/.sbt/1.0
-        printf 'realm=Sonatype Nexus Repository Manager\nhost=central.sonatype.com\nuser=%s\npassword=%s\n' \
+        printf 'host=central.sonatype.com\nuser=%s\npassword=%s\n' \
           "$SONATYPE_USERNAME" "$SONATYPE_PASSWORD" > ~/.sbt/1.0/sonatype_credentials
     - name: Import GPG key
       run: |

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -12,23 +12,39 @@ jobs:
     env:
       JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
       JVM_OPTS:  -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+      SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+      PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.workflow_run.head_branch }}
         fetch-depth: 0
-    - uses: actions/setup-java@v4
+    - uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '17'
         cache: 'sbt'
     - uses: sbt/setup-sbt@v1
-    - uses: olafurpg/setup-gpg@v3
-    - run: sbt -v ci-release
-      env:
-        PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-        PGP_SECRET: ${{ secrets.PGP_SECRET }}
-        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-        SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-    - name: clean up
-      run: "${GITHUB_WORKSPACE}/.github/clean-up.sh"
+    - name: Configure Sonatype credentials
+      run: |
+        mkdir -p ~/.sbt/1.0
+        printf 'realm=Sonatype Nexus Repository Manager\nhost=central.sonatype.com\nuser=%s\npassword=%s\n' \
+          "$SONATYPE_USERNAME" "$SONATYPE_PASSWORD" > ~/.sbt/1.0/sonatype_credentials
+        cat ~/.sbt/1.0/sonatype_credentials | sed 's/password=.*/password=***/'
+    - name: Import GPG key
+      run: |
+        mkdir -p ~/.gnupg
+        chmod 700 ~/.gnupg
+        echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+        echo "use-agent" >> ~/.gnupg/gpg.conf
+        echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
+        chmod 600 ~/.gnupg/gpg.conf ~/.gnupg/gpg-agent.conf
+        gpg-agent --daemon || true
+        echo "${{ secrets.PGP_SECRET }}" | base64 -d | gpg --batch --import
+        gpg --list-secret-keys
+    - name: Publish Snapshot
+      run: |
+        sbt \
+          'set every publishTo := Some("central-snapshots" at "https://central.sonatype.com/repository/maven-snapshots/")' \
+          +publishSigned

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -31,7 +31,6 @@ jobs:
         mkdir -p ~/.sbt/1.0
         printf 'realm=Sonatype Nexus Repository Manager\nhost=central.sonatype.com\nuser=%s\npassword=%s\n' \
           "$SONATYPE_USERNAME" "$SONATYPE_PASSWORD" > ~/.sbt/1.0/sonatype_credentials
-        cat ~/.sbt/1.0/sonatype_credentials | sed 's/password=.*/password=***/'
     - name: Import GPG key
       run: |
         mkdir -p ~/.gnupg

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,8 @@ def crossScalacOptions(scalaVersion: String): Seq[String] =
       Seq(
         "-source:3.0-migration",
         "-Xignore-scala2-macros",
-        "-Xtarget:17"
+        "-release",
+        "17"
       )
     case Some((2L, scalaMajor)) if scalaMajor >= 12 =>
       Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -1,19 +1,24 @@
 import Dependencies.Versions
 
+ThisBuild / credentials += Credentials(Path.userHome / ".sbt" / "1.0" / "sonatype_credentials")
+
 def crossScalacOptions(scalaVersion: String): Seq[String] =
   CrossVersion.partialVersion(scalaVersion) match {
     case Some((3L, _)) =>
       Seq(
         "-source:3.0-migration",
-        "-Xignore-scala2-macros"
+        "-Xignore-scala2-macros",
+        "-Xtarget:17"
       )
     case Some((2L, scalaMajor)) if scalaMajor >= 12 =>
       Seq(
         "-Ydelambdafy:method",
-        "-target:jvm-1.8",
+        "-release",
+        "17",
         "-Yrangepos",
         "-Ywarn-unused"
       )
+    case _ => Seq.empty
   }
 
 lazy val baseSettings = Seq(
@@ -39,11 +44,10 @@ lazy val baseSettings = Seq(
       "-language:_"
     ) ++ crossScalacOptions(scalaVersion.value)
   ),
-  resolvers ++= Resolver.sonatypeOssRepos("snapshots"),
-  resolvers ++= Resolver.sonatypeOssRepos("releases"),
-  ThisBuild / scalafixScalaBinaryVersion := CrossVersion.binaryScalaVersion(scalaVersion.value),
+  javacOptions ++= Seq("--release", "17"),
+  resolvers += Resolver.sonatypeCentralSnapshots,
   semanticdbEnabled := true,
-  semanticdbVersion := scalafixSemanticdb.revision,
+  semanticdbVersion := "4.14.2",
   Test / publishArtifact := false,
   Test / fork := true,
   Test / parallelExecution := false,
@@ -61,6 +65,7 @@ val core = (project in file("core"))
   .settings(baseSettings)
   .settings(
     name := "chronos-scheduler-scala-core",
+    crossScalaVersions := Seq(Versions.scala213Version, Versions.scala3Version),
     libraryDependencies ++= Seq(
       "com.github.j5ik2o" %% "chronos-parser-scala" % "1.1.5",
       "org.slf4j"          % "slf4j-api"            % "2.0.17",
@@ -75,6 +80,7 @@ val `akka-actor` = (project in file("akka-actor"))
   .settings(baseSettings)
   .settings(
     name := "chronos-scheduler-scala-akka-actor",
+    crossScalaVersions := Seq(Versions.scala213Version),
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-actor-typed"           % AkkaVersion,
       "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion,
@@ -90,6 +96,7 @@ val `example` = (project in file("example"))
   .settings(baseSettings)
   .settings(
     name := "chronos-scheduler-scala-example",
+    crossScalaVersions := Seq(Versions.scala213Version),
     libraryDependencies ++= Seq(
       "ch.qos.logback" % "logback-classic" % "1.5.32"
     )
@@ -99,7 +106,9 @@ val `example` = (project in file("example"))
 val root = (project in file("."))
   .settings(baseSettings)
   .settings(
-    name := "chronos-scheduler-scala-root"
+    name := "chronos-scheduler-scala-root",
+    crossScalaVersions := Seq(Versions.scala213Version),
+    publish / skip := true
   )
   .aggregate(core, `akka-actor`, `example`)
 


### PR DESCRIPTION
## Summary
- core モジュールに Scala 3.3.7 クロスコンパイルを追加（akka-actor/example は Akka 2.8.x 制約のため Scala 2.13 のみ）
- JDK ターゲットを 8 → 17 に引き上げ（scalac `-release 17`、javac `--release 17`）
- 非推奨の `Resolver.sonatypeOssRepos` を `Resolver.sonatypeCentralSnapshots` に置換
- 非推奨の `scalafixScalaBinaryVersion` 設定を削除
- release/snapshot ワークフローを Sonatype Central Portal 対応に刷新
- 非推奨/アーカイブ済み GitHub Actions を最新版に更新（checkout v6, setup-java v5, softprops/action-gh-release v2）
- `olafurpg/setup-gpg@v3` をインライン GPG 設定に置換
- bump-version の deprecated `set-output` を `$GITHUB_OUTPUT` に修正
- 未使用の `clean-up.sh` を削除

## Test plan
- [x] `sbt compile` / `sbt Test/compile` — Scala 2.13.18 成功
- [x] `sbt ++3.3.7 core/compile` / `core/Test/compile` — Scala 3.3.7 成功
- [x] `sbt test` — 全 3 テスト成功 (Scala 2.13)
- [x] `sbt ++3.3.7 core/test` — 1 テスト成功 (Scala 3)
- [x] `scalafmtCheck` / `scalafmtSbtCheck` — パス
- [ ] CI ワークフロー確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches build and CI/release automation (JDK/Scala matrix, publishing, credentials/GPG handling), which can break compilation or artifact publishing if misconfigured.
> 
> **Overview**
> **Modernizes the build to target JDK 17 and add Scala 3 support.** `build.sbt` now uses `-release 17`/`--release 17`, adds Sonatype Central credentials loading, updates resolver/semanticdb settings, enables Scala 3 cross-compilation for `core` (while keeping other modules/root on Scala 2.13), and skips publishing the root project.
> 
> **Updates GitHub Actions pipelines for current tooling and Central Portal publishing.** CI switches to newer `checkout`/`setup-java`, runs lint on Java 17, expands the test matrix to JDK 17/21 and Scala 2.13/3 (with Scala 3 only running `core/test`). Release/snapshot workflows inline Sonatype credential + GPG loopback setup and publish snapshots to Sonatype Central; bump-version replaces deprecated `set-output` and uses `softprops/action-gh-release`, and an unused cleanup script is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28357262e779b9ebdf02692eb4e9ac7f372c1c55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->