### PR TITLE
fix: Fix snapshot publishing - add SNAPSHOT version suffix and skip e…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,8 @@ jobs:
         echo "use-agent" >> ~/.gnupg/gpg.conf
         echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
         chmod 600 ~/.gnupg/gpg.conf ~/.gnupg/gpg-agent.conf
-        gpg-agent --daemon || true
+        gpgconf --kill gpg-agent
+        gpgconf --launch gpg-agent
     - run: sbt -v ci-release
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -8,13 +8,16 @@ on:
 jobs:
   snapshot:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_branch == 'main' }}
     env:
       JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
       JVM_OPTS:  -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
       SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
       SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
       PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+      PGP_SECRET: ${{ secrets.PGP_SECRET }}
     steps:
     - uses: actions/checkout@v6
       with:
@@ -39,11 +42,13 @@ jobs:
         echo "use-agent" >> ~/.gnupg/gpg.conf
         echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
         chmod 600 ~/.gnupg/gpg.conf ~/.gnupg/gpg-agent.conf
-        gpg-agent --daemon || true
-        echo "${{ secrets.PGP_SECRET }}" | base64 -d | gpg --batch --import
+        gpgconf --kill gpg-agent
+        gpgconf --launch gpg-agent
+        echo "$PGP_SECRET" | base64 -d | gpg --batch --import
         gpg --list-secret-keys
     - name: Publish Snapshot
       run: |
         sbt \
+          "set every pgpPassphrase := Some(sys.env(\"PGP_PASSPHRASE\").toCharArray)" \
           'set every publishTo := Some("central-snapshots" at "https://central.sonatype.com/repository/maven-snapshots/")' \
           +publishSigned

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import Dependencies.Versions
 
 ThisBuild / credentials += Credentials(Path.userHome / ".sbt" / "1.0" / "sonatype_credentials")
+ThisBuild / dynverSonatypeSnapshots := true
 
 def crossScalacOptions(scalaVersion: String): Seq[String] =
   CrossVersion.partialVersion(scalaVersion) match {
@@ -116,6 +117,7 @@ val `example` = (project in file("example"))
   .settings(
     name := "chronos-scheduler-scala-example",
     crossScalaVersions := Seq(Versions.scala213Version, Versions.scala3Version),
+    publish / skip := true,
     libraryDependencies ++= Seq(
       "ch.qos.logback" % "logback-classic" % "1.5.32"
     )


### PR DESCRIPTION
…xample module

- Add dynverSonatypeSnapshots := true to generate -SNAPSHOT versions for non-tagged commits
- Add publish/skip for example module to prevent unnecessary publishing
- Restrict snapshot workflow to main branch only (skip tag pushes)
- Fix GPG agent restart with gpgconf --kill/--launch in both workflows
- Add pgpPassphrase to snapshot sbt command

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect CI-driven artifact publishing (snapshot and release) and GPG signing setup; mistakes could break deployments or produce incorrectly versioned/signed artifacts, but scope is limited to build and workflow configuration.
> 
> **Overview**
> Ensures snapshot builds publish with proper `-SNAPSHOT` versions by enabling `dynverSonatypeSnapshots`, and avoids attempting to publish the `example` module (`publish / skip := true`).
> 
> Hardens GitHub Actions publishing: snapshot publishing now only runs for successful CI on `main`, snapshot signing explicitly sets `pgpPassphrase`, and both snapshot/release workflows restart the GPG agent via `gpgconf --kill/--launch` while sourcing `PGP_SECRET` from env for key import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e5ab0b603680a120eb6c4580e12d106bad52711. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->