### PR TITLE
refactor: rename Stop/Stopped to Shutdown/ShutdownCompleted

### DIFF
--- a/akka-actor/src/main/scala/com/github/j5ik2o/chronos/akka/JobSchedulerActor.scala
+++ b/akka-actor/src/main/scala/com/github/j5ik2o/chronos/akka/JobSchedulerActor.scala
@@ -21,8 +21,8 @@ object JobSchedulerProtocol {
   case class RemoveJobFailed(ex: Throwable) extends RemoveJobReply
 
   case class Tick(schedulerId: UUID) extends Command
-  case class Stop(schedulerId: UUID, replyTo: ActorRef[Stopped.type]) extends Command
-  case object Stopped extends Command
+  case class Shutdown(schedulerId: UUID, replyTo: ActorRef[ShutdownCompleted.type]) extends Command
+  case object ShutdownCompleted extends Command
 }
 
 object JobSchedulerActor {
@@ -45,8 +45,8 @@ object JobSchedulerActor {
           val newJobRefs = jobRefs - jobId
           replyTo ! JobSchedulerProtocol.RemoveJobSucceeded
           running(schedulerId, newJobRefs, clock)
-        case JobSchedulerProtocol.Stop(sid, replyTo) if schedulerId == sid =>
-          replyTo ! JobSchedulerProtocol.Stopped
+        case JobSchedulerProtocol.Shutdown(sid, replyTo) if schedulerId == sid =>
+          replyTo ! JobSchedulerProtocol.ShutdownCompleted
           Behaviors.stopped
         case JobSchedulerProtocol.Tick(sid) if schedulerId == sid =>
           jobRefs.foreach { case (_, jobRef) =>

--- a/akka-actor/src/main/scala/com/github/j5ik2o/chronos/akka/PersistentJobSchedulerActor.scala
+++ b/akka-actor/src/main/scala/com/github/j5ik2o/chronos/akka/PersistentJobSchedulerActor.scala
@@ -49,6 +49,8 @@ object PersistentJobSchedulerActor {
                 .thenReply(replyTo) { _ =>
                   JobSchedulerProtocol.RemoveJobSucceeded
                 }
+            case (EmptyState, JobSchedulerProtocol.Tick(_)) =>
+              Effect.noReply
             case (JustState(schedulerId, _), JobSchedulerProtocol.AddJob(sid, job, replyTo)) if schedulerId == sid =>
               Effect
                 .persist(JobSchedulerEvents.JobAdded(sid, job, replyTo)).thenReply(replyTo) { _ =>
@@ -64,9 +66,9 @@ object PersistentJobSchedulerActor {
                 .thenReply(replyTo) { _ =>
                   JobSchedulerProtocol.RemoveJobSucceeded
                 }
-            case (JustState(schedulerId, _), JobSchedulerProtocol.Stop(sid, replyTo)) if schedulerId == sid =>
+            case (JustState(schedulerId, _), JobSchedulerProtocol.Shutdown(sid, replyTo)) if schedulerId == sid =>
               Effect.stop().thenReply(replyTo) { _ =>
-                JobSchedulerProtocol.Stopped
+                JobSchedulerProtocol.ShutdownCompleted
               }
             case (JustState(schedulerId, jobs), JobSchedulerProtocol.Tick(sid)) if schedulerId == sid =>
               jobs.foreach { case (_, job) =>

--- a/akka-actor/src/test/scala/com/github/j5ik2o/chronos/akka/PersistentJobSchedulerActorSpec.scala
+++ b/akka-actor/src/test/scala/com/github/j5ik2o/chronos/akka/PersistentJobSchedulerActorSpec.scala
@@ -130,13 +130,13 @@ class PersistentJobSchedulerActorSpec
       removeReply.expectMessage(JobSchedulerProtocol.RemoveJobSucceeded)
     }
 
-    "stop in JustState" in {
+    "shutdown in JustState" in {
       val zoneId = ZoneId.systemDefault()
       val id     = UUID.randomUUID()
 
       val jobSchedulerActorRef = testKit.spawn(PersistentJobSchedulerActor(id))
       val addReply             = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
-      val stopReply            = testKit.createTestProbe[JobSchedulerProtocol.Stopped.type]()
+      val shutdownReply        = testKit.createTestProbe[JobSchedulerProtocol.ShutdownCompleted.type]()
 
       val job = Job(
         id = UUID.randomUUID(),
@@ -149,8 +149,8 @@ class PersistentJobSchedulerActorSpec
       jobSchedulerActorRef ! JobSchedulerProtocol.AddJob(id, job, addReply.ref)
       addReply.expectMessage(JobSchedulerProtocol.AddJobSucceeded)
 
-      jobSchedulerActorRef ! JobSchedulerProtocol.Stop(id, stopReply.ref)
-      stopReply.expectMessage(JobSchedulerProtocol.Stopped)
+      jobSchedulerActorRef ! JobSchedulerProtocol.Shutdown(id, shutdownReply.ref)
+      shutdownReply.expectMessage(JobSchedulerProtocol.ShutdownCompleted)
 
       testKit.createTestProbe().expectTerminated(jobSchedulerActorRef)
     }

--- a/pekko-actor/src/main/scala/com/github/j5ik2o/chronos/pekko/JobSchedulerActor.scala
+++ b/pekko-actor/src/main/scala/com/github/j5ik2o/chronos/pekko/JobSchedulerActor.scala
@@ -21,8 +21,8 @@ object JobSchedulerProtocol {
   case class RemoveJobFailed(ex: Throwable) extends RemoveJobReply
 
   case class Tick(schedulerId: UUID) extends Command
-  case class Stop(schedulerId: UUID, replyTo: ActorRef[Stopped.type]) extends Command
-  case object Stopped extends Command
+  case class Shutdown(schedulerId: UUID, replyTo: ActorRef[ShutdownCompleted.type]) extends Command
+  case object ShutdownCompleted extends Command
 }
 
 object JobSchedulerActor {
@@ -45,8 +45,8 @@ object JobSchedulerActor {
           val newJobRefs = jobRefs - jobId
           replyTo ! JobSchedulerProtocol.RemoveJobSucceeded
           running(schedulerId, newJobRefs, clock)
-        case JobSchedulerProtocol.Stop(sid, replyTo) if schedulerId == sid =>
-          replyTo ! JobSchedulerProtocol.Stopped
+        case JobSchedulerProtocol.Shutdown(sid, replyTo) if schedulerId == sid =>
+          replyTo ! JobSchedulerProtocol.ShutdownCompleted
           Behaviors.stopped
         case JobSchedulerProtocol.Tick(sid) if schedulerId == sid =>
           jobRefs.foreach { case (_, jobRef) =>

--- a/pekko-actor/src/main/scala/com/github/j5ik2o/chronos/pekko/PersistentJobSchedulerActor.scala
+++ b/pekko-actor/src/main/scala/com/github/j5ik2o/chronos/pekko/PersistentJobSchedulerActor.scala
@@ -49,6 +49,8 @@ object PersistentJobSchedulerActor {
                 .thenReply(replyTo) { _ =>
                   JobSchedulerProtocol.RemoveJobSucceeded
                 }
+            case (EmptyState, JobSchedulerProtocol.Tick(_)) =>
+              Effect.noReply
             case (JustState(schedulerId, _), JobSchedulerProtocol.AddJob(sid, job, replyTo)) if schedulerId == sid =>
               Effect
                 .persist(JobSchedulerEvents.JobAdded(sid, job, replyTo)).thenReply(replyTo) { _ =>
@@ -64,9 +66,9 @@ object PersistentJobSchedulerActor {
                 .thenReply(replyTo) { _ =>
                   JobSchedulerProtocol.RemoveJobSucceeded
                 }
-            case (JustState(schedulerId, _), JobSchedulerProtocol.Stop(sid, replyTo)) if schedulerId == sid =>
+            case (JustState(schedulerId, _), JobSchedulerProtocol.Shutdown(sid, replyTo)) if schedulerId == sid =>
               Effect.stop().thenReply(replyTo) { _ =>
-                JobSchedulerProtocol.Stopped
+                JobSchedulerProtocol.ShutdownCompleted
               }
             case (JustState(schedulerId, jobs), JobSchedulerProtocol.Tick(sid)) if schedulerId == sid =>
               jobs.foreach { case (_, job) =>

--- a/pekko-actor/src/test/scala/com/github/j5ik2o/chronos/pekko/PersistentJobSchedulerActorSpec.scala
+++ b/pekko-actor/src/test/scala/com/github/j5ik2o/chronos/pekko/PersistentJobSchedulerActorSpec.scala
@@ -130,13 +130,13 @@ class PersistentJobSchedulerActorSpec
       removeReply.expectMessage(JobSchedulerProtocol.RemoveJobSucceeded)
     }
 
-    "stop in JustState" in {
+    "shutdown in JustState" in {
       val zoneId = ZoneId.systemDefault()
       val id     = UUID.randomUUID()
 
       val jobSchedulerActorRef = testKit.spawn(PersistentJobSchedulerActor(id))
       val addReply             = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
-      val stopReply            = testKit.createTestProbe[JobSchedulerProtocol.Stopped.type]()
+      val shutdownReply        = testKit.createTestProbe[JobSchedulerProtocol.ShutdownCompleted.type]()
 
       val job = Job(
         id = UUID.randomUUID(),
@@ -149,8 +149,8 @@ class PersistentJobSchedulerActorSpec
       jobSchedulerActorRef ! JobSchedulerProtocol.AddJob(id, job, addReply.ref)
       addReply.expectMessage(JobSchedulerProtocol.AddJobSucceeded)
 
-      jobSchedulerActorRef ! JobSchedulerProtocol.Stop(id, stopReply.ref)
-      stopReply.expectMessage(JobSchedulerProtocol.Stopped)
+      jobSchedulerActorRef ! JobSchedulerProtocol.Shutdown(id, shutdownReply.ref)
+      shutdownReply.expectMessage(JobSchedulerProtocol.ShutdownCompleted)
 
       testKit.createTestProbe().expectTerminated(jobSchedulerActorRef)
     }


### PR DESCRIPTION
## Summary

- `Stop` コマンドを `Shutdown` に改名（完全終了の意図を明確化）
- `Stopped` 返信を `ShutdownCompleted` に改名（`AddJobSucceeded` / `RemoveJobSucceeded` との命名一貫性）
- `EmptyState` + `Tick` に `Effect.noReply` を追加（`withEnforcedReplies` での unhandled 警告を防止）

## Test plan

- [x] 既存テストがすべてパスすること（テスト名も `"shutdown in JustState"` に更新済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk rename/behavioral cleanup limited to scheduler actor message types; main risk is downstream compile breaks for any external callers still using `Stop`/`Stopped`.
> 
> **Overview**
> **Renames the scheduler termination protocol** in both Akka and Pekko implementations: `Stop`/`Stopped` becomes `Shutdown`/`ShutdownCompleted`, with corresponding updates to actor handlers and specs.
> 
> **Fixes enforced-replies warnings** in persistent schedulers by explicitly handling `Tick` in `EmptyState` with `Effect.noReply`, preventing unhandled-command noise during startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7478385139dff72c262f778a69e2254be30e5708. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->