### PR TITLE
feat: replace run: () => Unit with sendTo/message in Job[CMD]

### DIFF
--- a/akka-actor/src/main/scala/com/github/j5ik2o/chronos/akka/JobActor.scala
+++ b/akka-actor/src/main/scala/com/github/j5ik2o/chronos/akka/JobActor.scala
@@ -1,21 +1,36 @@
 package com.github.j5ik2o.chronos.akka
 
-import akka.actor.typed.Behavior
+import akka.actor.typed.{ ActorRef, Behavior }
 import akka.actor.typed.scaladsl.Behaviors
-import com.github.j5ik2o.chronos.core.Job
+import com.fasterxml.jackson.annotation.{ JsonIgnore, JsonTypeInfo }
+import com.github.j5ik2o.cron.CronSchedule
 
-import java.time.{ Duration, Instant }
+import java.time.{ Duration, Instant, ZoneId }
+import java.util.UUID
+import scala.concurrent.duration._
+
+case class Job[CMD](
+    id: UUID,
+    cronExpression: String,
+    zoneId: ZoneId,
+    limitMissedRuns: Int = 5,
+    tickInterval: FiniteDuration = 1.minutes,
+    sendTo: ActorRef[CMD],
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS) message: CMD
+) extends CborSerializable {
+  @JsonIgnore private[chronos] lazy val schedule: CronSchedule = CronSchedule(cronExpression, zoneId)
+  @JsonIgnore private[chronos] def dispatch(): Unit             = sendTo ! message
+}
 
 object JobProtocol {
   sealed trait Command
   case object Tick extends Command
-  case object Run extends Command
-
+  case object Run  extends Command
 }
 
 object JobActor {
 
-  private def started(job: Job, clock: () => Instant)(
+  private def started(job: Job[_], clock: () => Instant)(
       lastTick: Option[Instant]
   ): Behavior[JobProtocol.Command] = {
     Behaviors.setup[JobProtocol.Command] { _ =>
@@ -23,13 +38,13 @@ object JobActor {
         case JobProtocol.Tick =>
           Behaviors.same
         case JobProtocol.Run =>
-          job.run()
+          job.dispatch()
           notStarted(job, clock)(lastTick)
       }
     }
   }
 
-  private def notStarted(job: Job, clock: () => Instant)(
+  private def notStarted(job: Job[_], clock: () => Instant)(
       lastTick: Option[Instant]
   ): Behavior[JobProtocol.Command] = {
     Behaviors.setup { ctx =>
@@ -62,7 +77,7 @@ object JobActor {
   }
 
   def apply(
-      job: Job,
+      job: Job[_],
       clock: () => Instant = () => Instant.now()
   ): Behavior[JobProtocol.Command] = {
     notStarted(job, clock)(None)

--- a/akka-actor/src/main/scala/com/github/j5ik2o/chronos/akka/JobActor.scala
+++ b/akka-actor/src/main/scala/com/github/j5ik2o/chronos/akka/JobActor.scala
@@ -19,13 +19,13 @@ case class Job[CMD](
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS) message: CMD
 ) extends CborSerializable {
   @JsonIgnore private[chronos] lazy val schedule: CronSchedule = CronSchedule(cronExpression, zoneId)
-  @JsonIgnore private[chronos] def dispatch(): Unit             = sendTo ! message
+  @JsonIgnore private[chronos] def dispatch(): Unit            = sendTo ! message
 }
 
 object JobProtocol {
   sealed trait Command
   case object Tick extends Command
-  case object Run  extends Command
+  case object Run extends Command
 }
 
 object JobActor {

--- a/akka-actor/src/main/scala/com/github/j5ik2o/chronos/akka/JobSchedulerActor.scala
+++ b/akka-actor/src/main/scala/com/github/j5ik2o/chronos/akka/JobSchedulerActor.scala
@@ -11,21 +11,21 @@ object JobSchedulerProtocol {
   sealed trait Command
   case class AddJob(schedulerId: UUID, job: Job[_], replyTo: ActorRef[AddJobReply]) extends Command
   sealed trait AddJobReply
-  case object AddJobSucceeded                       extends AddJobReply
-  case class AddJobFailed(ex: Throwable)            extends AddJobReply
+  case object AddJobSucceeded extends AddJobReply
+  case class AddJobFailed(ex: Throwable) extends AddJobReply
 
   case class RemoveJob(schedulerId: UUID, jobId: UUID, replyTo: ActorRef[RemoveJobReply]) extends Command
   sealed trait RemoveJobReply
-  case object RemoveJobSucceeded                    extends RemoveJobReply
-  case class RemoveJobFailed(ex: Throwable)         extends RemoveJobReply
+  case object RemoveJobSucceeded extends RemoveJobReply
+  case class RemoveJobFailed(ex: Throwable) extends RemoveJobReply
 
   case class GetJobs(schedulerId: UUID, replyTo: ActorRef[GetJobsReply]) extends Command
   sealed trait GetJobsReply
-  case class GetJobsResponse(jobs: Seq[Job[_]])     extends GetJobsReply
+  case class GetJobsResponse(jobs: Seq[Job[_]]) extends GetJobsReply
 
-  case class Tick(schedulerId: UUID)                                                      extends Command
-  case class Shutdown(schedulerId: UUID, replyTo: ActorRef[ShutdownCompleted.type])       extends Command
-  case object ShutdownCompleted                     extends Command
+  case class Tick(schedulerId: UUID) extends Command
+  case class Shutdown(schedulerId: UUID, replyTo: ActorRef[ShutdownCompleted.type]) extends Command
+  case object ShutdownCompleted extends Command
 }
 
 object JobSchedulerActor {

--- a/akka-actor/src/main/scala/com/github/j5ik2o/chronos/akka/JobSchedulerActor.scala
+++ b/akka-actor/src/main/scala/com/github/j5ik2o/chronos/akka/JobSchedulerActor.scala
@@ -2,7 +2,6 @@ package com.github.j5ik2o.chronos.akka
 
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ ActorRef, Behavior }
-import com.github.j5ik2o.chronos.core.Job
 
 import java.time.Instant
 import java.util.UUID
@@ -10,46 +9,52 @@ import scala.concurrent.duration._
 
 object JobSchedulerProtocol {
   sealed trait Command
-  case class AddJob(schedulerId: UUID, job: Job, replyTo: ActorRef[AddJobReply]) extends Command
+  case class AddJob(schedulerId: UUID, job: Job[_], replyTo: ActorRef[AddJobReply]) extends Command
   sealed trait AddJobReply
-  case object AddJobSucceeded extends AddJobReply
-  case class AddJobFailed(ex: Throwable) extends AddJobReply
+  case object AddJobSucceeded                       extends AddJobReply
+  case class AddJobFailed(ex: Throwable)            extends AddJobReply
 
   case class RemoveJob(schedulerId: UUID, jobId: UUID, replyTo: ActorRef[RemoveJobReply]) extends Command
   sealed trait RemoveJobReply
-  case object RemoveJobSucceeded extends RemoveJobReply
-  case class RemoveJobFailed(ex: Throwable) extends RemoveJobReply
+  case object RemoveJobSucceeded                    extends RemoveJobReply
+  case class RemoveJobFailed(ex: Throwable)         extends RemoveJobReply
 
-  case class Tick(schedulerId: UUID) extends Command
-  case class Shutdown(schedulerId: UUID, replyTo: ActorRef[ShutdownCompleted.type]) extends Command
-  case object ShutdownCompleted extends Command
+  case class GetJobs(schedulerId: UUID, replyTo: ActorRef[GetJobsReply]) extends Command
+  sealed trait GetJobsReply
+  case class GetJobsResponse(jobs: Seq[Job[_]])     extends GetJobsReply
+
+  case class Tick(schedulerId: UUID)                                                      extends Command
+  case class Shutdown(schedulerId: UUID, replyTo: ActorRef[ShutdownCompleted.type])       extends Command
+  case object ShutdownCompleted                     extends Command
 }
 
 object JobSchedulerActor {
 
   private def running(
       schedulerId: UUID,
-      jobRefs: Map[UUID, ActorRef[JobProtocol.Command]],
+      jobs: Map[UUID, (Job[_], ActorRef[JobProtocol.Command])],
       clock: () => Instant
   ): Behavior[JobSchedulerProtocol.Command] = {
     Behaviors.setup { ctx =>
       Behaviors.receiveMessagePartial {
         case JobSchedulerProtocol.AddJob(sid, job, replyTo) if schedulerId == sid =>
-          val jobRef     = ctx.spawn(JobActor(job, clock), job.id.toString)
-          val newJobRefs = jobRefs + (job.id -> jobRef)
+          val jobRef  = ctx.spawn(JobActor(job, clock), job.id.toString)
+          val newJobs = jobs + (job.id -> (job, jobRef))
           replyTo ! JobSchedulerProtocol.AddJobSucceeded
-          running(schedulerId, newJobRefs, clock)
+          running(schedulerId, newJobs, clock)
         case JobSchedulerProtocol.RemoveJob(sid, jobId, replyTo) if schedulerId == sid =>
-          val jobRef = jobRefs.get(jobId)
-          jobRef.foreach(ref => ctx.stop(ref))
-          val newJobRefs = jobRefs - jobId
+          jobs.get(jobId).foreach { case (_, ref) => ctx.stop(ref) }
+          val newJobs = jobs - jobId
           replyTo ! JobSchedulerProtocol.RemoveJobSucceeded
-          running(schedulerId, newJobRefs, clock)
+          running(schedulerId, newJobs, clock)
+        case JobSchedulerProtocol.GetJobs(sid, replyTo) if schedulerId == sid =>
+          replyTo ! JobSchedulerProtocol.GetJobsResponse(jobs.values.map(_._1).toSeq)
+          Behaviors.same
         case JobSchedulerProtocol.Shutdown(sid, replyTo) if schedulerId == sid =>
           replyTo ! JobSchedulerProtocol.ShutdownCompleted
           Behaviors.stopped
         case JobSchedulerProtocol.Tick(sid) if schedulerId == sid =>
-          jobRefs.foreach { case (_, jobRef) =>
+          jobs.foreach { case (_, (_, jobRef)) =>
             jobRef ! JobProtocol.Tick
           }
           Behaviors.same

--- a/akka-actor/src/main/scala/com/github/j5ik2o/chronos/akka/PersistentJobSchedulerActor.scala
+++ b/akka-actor/src/main/scala/com/github/j5ik2o/chronos/akka/PersistentJobSchedulerActor.scala
@@ -12,15 +12,15 @@ import scala.concurrent.duration.FiniteDuration
 
 object JobSchedulerEvents {
   sealed trait Event extends CborSerializable
-  case class JobAdded(schedulerId: UUID, job: Job[_], replyTo: ActorRef[AddJobReply])    extends Event
+  case class JobAdded(schedulerId: UUID, job: Job[_], replyTo: ActorRef[AddJobReply]) extends Event
   case class JobRemoved(schedulerId: UUID, jobID: UUID, replyTo: ActorRef[RemoveJobReply]) extends Event
 }
 
 object PersistentJobSchedulerActor {
 
   sealed trait State
-  case object EmptyState                                              extends State
-  case class JustState(schedulerId: UUID, jobs: Map[UUID, Job[_]])   extends State
+  case object EmptyState extends State
+  case class JustState(schedulerId: UUID, jobs: Map[UUID, Job[_]]) extends State
 
   def apply(
       id: UUID,

--- a/akka-actor/src/main/scala/com/github/j5ik2o/chronos/akka/PersistentJobSchedulerActor.scala
+++ b/akka-actor/src/main/scala/com/github/j5ik2o/chronos/akka/PersistentJobSchedulerActor.scala
@@ -5,7 +5,6 @@ import akka.actor.typed.{ ActorRef, Behavior }
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.scaladsl.{ Effect, EventSourcedBehavior }
 import com.github.j5ik2o.chronos.akka.JobSchedulerProtocol.{ AddJobReply, RemoveJobReply }
-import com.github.j5ik2o.chronos.core.Job
 
 import java.time.Instant
 import java.util.UUID
@@ -13,15 +12,15 @@ import scala.concurrent.duration.FiniteDuration
 
 object JobSchedulerEvents {
   sealed trait Event extends CborSerializable
-  case class JobAdded(schedulerId: UUID, job: Job, replyTo: ActorRef[AddJobReply]) extends Event
+  case class JobAdded(schedulerId: UUID, job: Job[_], replyTo: ActorRef[AddJobReply])    extends Event
   case class JobRemoved(schedulerId: UUID, jobID: UUID, replyTo: ActorRef[RemoveJobReply]) extends Event
 }
 
 object PersistentJobSchedulerActor {
 
   sealed trait State
-  case object EmptyState extends State
-  case class JustState(schedulerId: UUID, jobs: Map[UUID, Job]) extends State
+  case object EmptyState                                              extends State
+  case class JustState(schedulerId: UUID, jobs: Map[UUID, Job[_]])   extends State
 
   def apply(
       id: UUID,
@@ -51,6 +50,8 @@ object PersistentJobSchedulerActor {
                 }
             case (EmptyState, JobSchedulerProtocol.Tick(_)) =>
               Effect.noReply
+            case (EmptyState, JobSchedulerProtocol.GetJobs(_, replyTo)) =>
+              Effect.reply(replyTo)(JobSchedulerProtocol.GetJobsResponse(Seq.empty))
             case (JustState(schedulerId, _), JobSchedulerProtocol.AddJob(sid, job, replyTo)) if schedulerId == sid =>
               Effect
                 .persist(JobSchedulerEvents.JobAdded(sid, job, replyTo)).thenReply(replyTo) { _ =>
@@ -66,6 +67,8 @@ object PersistentJobSchedulerActor {
                 .thenReply(replyTo) { _ =>
                   JobSchedulerProtocol.RemoveJobSucceeded
                 }
+            case (JustState(schedulerId, jobs), JobSchedulerProtocol.GetJobs(sid, replyTo)) if schedulerId == sid =>
+              Effect.reply(replyTo)(JobSchedulerProtocol.GetJobsResponse(jobs.values.toSeq))
             case (JustState(schedulerId, _), JobSchedulerProtocol.Shutdown(sid, replyTo)) if schedulerId == sid =>
               Effect.stop().thenReply(replyTo) { _ =>
                 JobSchedulerProtocol.ShutdownCompleted
@@ -89,7 +92,6 @@ object PersistentJobSchedulerActor {
               JustState(schedulerId, jobs - jobId)
           }
         )
-
       }
     }
   }

--- a/akka-actor/src/test/scala/com/github/j5ik2o/chronos/akka/JobSchedulerActorSpec.scala
+++ b/akka-actor/src/test/scala/com/github/j5ik2o/chronos/akka/JobSchedulerActorSpec.scala
@@ -24,7 +24,7 @@ class JobSchedulerActorSpec extends AnyFunSuite {
     val jobSchedulerActorRef = testKit.spawn(JobSchedulerActor(id, clock = clock))
 
     val reply = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
-    val job = Job(
+    val job   = Job(
       id = UUID.randomUUID(),
       cronExpression = "*/1 * * * *",
       zoneId,
@@ -69,7 +69,7 @@ class JobSchedulerActorSpec extends AnyFunSuite {
     val jobSchedulerActorRef = testKit.spawn(JobSchedulerActor(id, clock = clock))
 
     val reply = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
-    val job = Job(
+    val job   = Job(
       id = UUID.randomUUID(),
       cronExpression = "*/1 * * * *",
       zoneId,
@@ -128,7 +128,7 @@ class JobSchedulerActorSpec extends AnyFunSuite {
     val jobSchedulerActorRef = testKit.spawn(JobSchedulerActor(id, clock = clock))
 
     val reply = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
-    val job = Job(
+    val job   = Job(
       id = UUID.randomUUID(),
       cronExpression = "*/1 * * * *",
       zoneId,

--- a/akka-actor/src/test/scala/com/github/j5ik2o/chronos/akka/JobSchedulerActorSpec.scala
+++ b/akka-actor/src/test/scala/com/github/j5ik2o/chronos/akka/JobSchedulerActorSpec.scala
@@ -1,7 +1,6 @@
 package com.github.j5ik2o.chronos.akka
 
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
-import com.github.j5ik2o.chronos.core.Job
 import org.scalatest.funsuite.AnyFunSuite
 
 import java.time.{ Instant, ZoneId }
@@ -13,101 +12,129 @@ class JobSchedulerActorSpec extends AnyFunSuite {
 
   val testKit: ActorTestKit = ActorTestKit()
 
+  sealed trait TestMessage extends CborSerializable
+  case object DoWork extends TestMessage
+
   test("job fires only on cron boundary") {
     val zoneId               = ZoneId.of("UTC")
     val mockTime             = new AtomicReference[Instant](Instant.parse("2024-01-01T12:00:00Z"))
     val clock: () => Instant = () => mockTime.get()
-    var counter              = 0
     val id                   = UUID.randomUUID()
+    val probe                = testKit.createTestProbe[TestMessage]()
     val jobSchedulerActorRef = testKit.spawn(JobSchedulerActor(id, clock = clock))
 
     val reply = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
-    val job   = Job(
+    val job = Job(
       id = UUID.randomUUID(),
       cronExpression = "*/1 * * * *",
       zoneId,
       tickInterval = 500.millis,
-      run = { () => counter += 1 }
+      sendTo = probe.ref,
+      message = DoWork
     )
     jobSchedulerActorRef ! JobSchedulerProtocol.AddJob(id, job, reply.ref)
     reply.expectMessage(JobSchedulerProtocol.AddJobSucceeded)
 
     // Tick 1: initialize lastTick
     jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-    Thread.sleep(200)
-    assert(counter == 0)
+    probe.expectNoMessage(200.millis)
 
     // Tick 2: tickInterval elapsed, but no cron period passed
     mockTime.set(Instant.parse("2024-01-01T12:00:00.600Z"))
     jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-    Thread.sleep(200)
-    assert(counter == 0)
+    probe.expectNoMessage(200.millis)
 
     // Tick 3: past cron boundary (12:01:00)
     mockTime.set(Instant.parse("2024-01-01T12:01:00.100Z"))
     jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-    Thread.sleep(200)
-    assert(counter == 1)
+    probe.expectMessage(DoWork)
 
     // Tick 4: not yet next cron boundary
     mockTime.set(Instant.parse("2024-01-01T12:01:00.700Z"))
     jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-    Thread.sleep(200)
-    assert(counter == 1)
+    probe.expectNoMessage(200.millis)
 
     // Tick 5: past next cron boundary
     mockTime.set(Instant.parse("2024-01-01T12:02:00.200Z"))
     jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-    Thread.sleep(200)
-    assert(counter == 2)
+    probe.expectMessage(DoWork)
   }
 
   test("job does not fire when limitMissedRuns exceeded") {
     val zoneId               = ZoneId.of("UTC")
     val mockTime             = new AtomicReference[Instant](Instant.parse("2024-01-01T12:00:00Z"))
     val clock: () => Instant = () => mockTime.get()
-    var counter              = 0
     val id                   = UUID.randomUUID()
+    val probe                = testKit.createTestProbe[TestMessage]()
     val jobSchedulerActorRef = testKit.spawn(JobSchedulerActor(id, clock = clock))
 
     val reply = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
-    val job   = Job(
+    val job = Job(
       id = UUID.randomUUID(),
       cronExpression = "*/1 * * * *",
       zoneId,
       limitMissedRuns = 3,
       tickInterval = 500.millis,
-      run = { () => counter += 1 }
+      sendTo = probe.ref,
+      message = DoWork
     )
     jobSchedulerActorRef ! JobSchedulerProtocol.AddJob(id, job, reply.ref)
     reply.expectMessage(JobSchedulerProtocol.AddJobSucceeded)
 
     // Tick 1: initialize
     jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-    Thread.sleep(200)
+    probe.expectNoMessage(200.millis)
 
     // Tick 2: jump 10 minutes ahead (missed more than 3 runs)
     mockTime.set(Instant.parse("2024-01-01T12:10:00.100Z"))
     jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-    Thread.sleep(200)
-    assert(counter == 0)
+    probe.expectNoMessage(200.millis)
+  }
+
+  test("GetJobs returns added jobs") {
+    val zoneId               = ZoneId.of("UTC")
+    val id                   = UUID.randomUUID()
+    val probe                = testKit.createTestProbe[TestMessage]()
+    val jobSchedulerActorRef = testKit.spawn(JobSchedulerActor(id))
+    val addReply             = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
+    val getReply             = testKit.createTestProbe[JobSchedulerProtocol.GetJobsReply]()
+
+    val job = Job(
+      id = UUID.randomUUID(),
+      cronExpression = "*/1 * * * *",
+      zoneId,
+      tickInterval = 500.millis,
+      sendTo = probe.ref,
+      message = DoWork
+    )
+
+    jobSchedulerActorRef ! JobSchedulerProtocol.GetJobs(id, getReply.ref)
+    getReply.expectMessage(JobSchedulerProtocol.GetJobsResponse(Seq.empty))
+
+    jobSchedulerActorRef ! JobSchedulerProtocol.AddJob(id, job, addReply.ref)
+    addReply.expectMessage(JobSchedulerProtocol.AddJobSucceeded)
+
+    jobSchedulerActorRef ! JobSchedulerProtocol.GetJobs(id, getReply.ref)
+    val response = getReply.expectMessageType[JobSchedulerProtocol.GetJobsResponse]
+    assert(response.jobs.map(_.id) == Seq(job.id))
   }
 
   test("rapid ticks do not cause errors") {
     val zoneId               = ZoneId.of("UTC")
     val mockTime             = new AtomicReference[Instant](Instant.parse("2024-01-01T12:00:00Z"))
     val clock: () => Instant = () => mockTime.get()
-    var counter              = 0
     val id                   = UUID.randomUUID()
+    val probe                = testKit.createTestProbe[TestMessage]()
     val jobSchedulerActorRef = testKit.spawn(JobSchedulerActor(id, clock = clock))
 
     val reply = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
-    val job   = Job(
+    val job = Job(
       id = UUID.randomUUID(),
       cronExpression = "*/1 * * * *",
       zoneId,
       tickInterval = 500.millis,
-      run = { () => counter += 1 }
+      sendTo = probe.ref,
+      message = DoWork
     )
     jobSchedulerActorRef ! JobSchedulerProtocol.AddJob(id, job, reply.ref)
     reply.expectMessage(JobSchedulerProtocol.AddJobSucceeded)
@@ -116,7 +143,6 @@ class JobSchedulerActorSpec extends AnyFunSuite {
     for (_ <- 1 to 10) {
       jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
     }
-    Thread.sleep(200)
-    assert(counter == 0)
+    probe.expectNoMessage(200.millis)
   }
 }

--- a/akka-actor/src/test/scala/com/github/j5ik2o/chronos/akka/PersistentJobSchedulerActorSpec.scala
+++ b/akka-actor/src/test/scala/com/github/j5ik2o/chronos/akka/PersistentJobSchedulerActorSpec.scala
@@ -1,14 +1,13 @@
 package com.github.j5ik2o.chronos.akka
 
 import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import com.github.j5ik2o.chronos.core.Job
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.freespec.AnyFreeSpecLike
 
 import java.time.{ Instant, ZoneId }
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration._
 
 object PersistentJobSchedulerActorSpec {
   val config: Config = ConfigFactory.parseString(s"""
@@ -26,13 +25,16 @@ class PersistentJobSchedulerActorSpec
     extends ScalaTestWithActorTestKit(PersistentJobSchedulerActorSpec.config)
     with AnyFreeSpecLike {
 
+  sealed trait TestMessage extends CborSerializable
+  case object DoWork extends TestMessage
+
   "PersistentJobSchedulerActor" - {
     "job fires only on cron boundary" in {
       val zoneId               = ZoneId.of("UTC")
       val mockTime             = new AtomicReference[Instant](Instant.parse("2024-01-01T12:00:00Z"))
       val clock: () => Instant = () => mockTime.get()
-      var counter              = 0
       val id                   = UUID.randomUUID()
+      val probe                = testKit.createTestProbe[TestMessage]()
 
       val jobSchedulerActorRef = testKit.spawn(PersistentJobSchedulerActor(id, clock = clock))
       val reply                = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
@@ -42,44 +44,41 @@ class PersistentJobSchedulerActorSpec
         cronExpression = "*/1 * * * *",
         zoneId,
         tickInterval = 500.millis,
-        run = { () => counter += 1 }
+        sendTo = probe.ref,
+        message = DoWork
       )
       jobSchedulerActorRef ! JobSchedulerProtocol.AddJob(id, job, reply.ref)
       reply.expectMessage(JobSchedulerProtocol.AddJobSucceeded)
 
       // Tick 1: initialize lastTick
       jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-      Thread.sleep(200)
-      assert(counter == 0)
+      probe.expectNoMessage(200.millis)
 
       // Tick 2: tickInterval elapsed, but no cron period passed
       mockTime.set(Instant.parse("2024-01-01T12:00:00.600Z"))
       jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-      Thread.sleep(200)
-      assert(counter == 0)
+      probe.expectNoMessage(200.millis)
 
       // Tick 3: past cron boundary
       mockTime.set(Instant.parse("2024-01-01T12:01:00.100Z"))
       jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-      Thread.sleep(200)
-      assert(counter == 1)
+      probe.expectMessage(DoWork)
 
       // Tick 4: not yet next cron boundary
       mockTime.set(Instant.parse("2024-01-01T12:01:00.700Z"))
       jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-      Thread.sleep(200)
-      assert(counter == 1)
+      probe.expectNoMessage(200.millis)
 
       // Tick 5: past next cron boundary
       mockTime.set(Instant.parse("2024-01-01T12:02:00.200Z"))
       jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-      Thread.sleep(200)
-      assert(counter == 2)
+      probe.expectMessage(DoWork)
     }
 
     "add multiple jobs in JustState" in {
       val zoneId = ZoneId.systemDefault()
       val id     = UUID.randomUUID()
+      val probe  = testKit.createTestProbe[TestMessage]()
 
       val jobSchedulerActorRef = testKit.spawn(PersistentJobSchedulerActor(id))
       val reply1               = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
@@ -90,14 +89,16 @@ class PersistentJobSchedulerActorSpec
         cronExpression = "*/1 * * * *",
         zoneId,
         tickInterval = 500.millis,
-        run = { () => () }
+        sendTo = probe.ref,
+        message = DoWork
       )
       val job2 = Job(
         id = UUID.randomUUID(),
         cronExpression = "*/1 * * * *",
         zoneId,
         tickInterval = 500.millis,
-        run = { () => () }
+        sendTo = probe.ref,
+        message = DoWork
       )
 
       jobSchedulerActorRef ! JobSchedulerProtocol.AddJob(id, job1, reply1.ref)
@@ -110,6 +111,7 @@ class PersistentJobSchedulerActorSpec
     "remove job in JustState" in {
       val zoneId = ZoneId.systemDefault()
       val id     = UUID.randomUUID()
+      val probe  = testKit.createTestProbe[TestMessage]()
 
       val jobSchedulerActorRef = testKit.spawn(PersistentJobSchedulerActor(id))
       val addReply             = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
@@ -120,7 +122,8 @@ class PersistentJobSchedulerActorSpec
         cronExpression = "*/1 * * * *",
         zoneId,
         tickInterval = 500.millis,
-        run = { () => () }
+        sendTo = probe.ref,
+        message = DoWork
       )
 
       jobSchedulerActorRef ! JobSchedulerProtocol.AddJob(id, job, addReply.ref)
@@ -130,9 +133,44 @@ class PersistentJobSchedulerActorSpec
       removeReply.expectMessage(JobSchedulerProtocol.RemoveJobSucceeded)
     }
 
+    "GetJobs returns empty in EmptyState" in {
+      val id                   = UUID.randomUUID()
+      val jobSchedulerActorRef = testKit.spawn(PersistentJobSchedulerActor(id))
+      val getReply             = testKit.createTestProbe[JobSchedulerProtocol.GetJobsReply]()
+
+      jobSchedulerActorRef ! JobSchedulerProtocol.GetJobs(id, getReply.ref)
+      getReply.expectMessage(JobSchedulerProtocol.GetJobsResponse(Seq.empty))
+    }
+
+    "GetJobs returns added jobs in JustState" in {
+      val zoneId               = ZoneId.systemDefault()
+      val id                   = UUID.randomUUID()
+      val probe                = testKit.createTestProbe[TestMessage]()
+      val jobSchedulerActorRef = testKit.spawn(PersistentJobSchedulerActor(id))
+      val addReply             = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
+      val getReply             = testKit.createTestProbe[JobSchedulerProtocol.GetJobsReply]()
+
+      val job = Job(
+        id = UUID.randomUUID(),
+        cronExpression = "*/1 * * * *",
+        zoneId,
+        tickInterval = 500.millis,
+        sendTo = probe.ref,
+        message = DoWork
+      )
+
+      jobSchedulerActorRef ! JobSchedulerProtocol.AddJob(id, job, addReply.ref)
+      addReply.expectMessage(JobSchedulerProtocol.AddJobSucceeded)
+
+      jobSchedulerActorRef ! JobSchedulerProtocol.GetJobs(id, getReply.ref)
+      val response = getReply.expectMessageType[JobSchedulerProtocol.GetJobsResponse]
+      assert(response.jobs.map(_.id) == Seq(job.id))
+    }
+
     "shutdown in JustState" in {
       val zoneId = ZoneId.systemDefault()
       val id     = UUID.randomUUID()
+      val probe  = testKit.createTestProbe[TestMessage]()
 
       val jobSchedulerActorRef = testKit.spawn(PersistentJobSchedulerActor(id))
       val addReply             = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
@@ -143,7 +181,8 @@ class PersistentJobSchedulerActorSpec
         cronExpression = "*/1 * * * *",
         zoneId,
         tickInterval = 500.millis,
-        run = { () => () }
+        sendTo = probe.ref,
+        message = DoWork
       )
 
       jobSchedulerActorRef ! JobSchedulerProtocol.AddJob(id, job, addReply.ref)

--- a/example/src/main/scala/com/github/j5ik2o/chronos/example/AkkaActorMain.scala
+++ b/example/src/main/scala/com/github/j5ik2o/chronos/example/AkkaActorMain.scala
@@ -16,7 +16,7 @@ object AkkaActorMain extends App {
 
   sealed trait Command
   case class WrappedAddJobReply(reply: JobSchedulerProtocol.AddJobReply) extends Command
-  case class WorkerMessage(msg: AppMessage)                               extends Command
+  case class WorkerMessage(msg: AppMessage) extends Command
 
   val system: ActorSystem[Command] = ActorSystem(apply, "job-scheduler-actor-main")
 
@@ -26,10 +26,9 @@ object AkkaActorMain extends App {
     val id      = UUID.randomUUID()
 
     val workerRef = ctx.spawn(
-      Behaviors.receiveMessage[AppMessage] {
-        case PrintMessage(text) =>
-          println(text)
-          Behaviors.same
+      Behaviors.receiveMessage[AppMessage] { case PrintMessage(text) =>
+        println(text)
+        Behaviors.same
       },
       "worker"
     )

--- a/example/src/main/scala/com/github/j5ik2o/chronos/example/AkkaActorMain.scala
+++ b/example/src/main/scala/com/github/j5ik2o/chronos/example/AkkaActorMain.scala
@@ -16,14 +16,12 @@ object AkkaActorMain extends App {
 
   sealed trait Command
   case class WrappedAddJobReply(reply: JobSchedulerProtocol.AddJobReply) extends Command
-  case class WorkerMessage(msg: AppMessage) extends Command
 
   val system: ActorSystem[Command] = ActorSystem(apply, "job-scheduler-actor-main")
 
   def apply: Behavior[Command] = Behaviors.setup[Command] { ctx =>
-    val zoneId  = ZoneId.systemDefault()
-    var counter = 0
-    val id      = UUID.randomUUID()
+    val zoneId = ZoneId.systemDefault()
+    val id     = UUID.randomUUID()
 
     val workerRef = ctx.spawn(
       Behaviors.receiveMessage[AppMessage] { case PrintMessage(text) =>
@@ -42,13 +40,12 @@ object AkkaActorMain extends App {
         cronExpression = "*/1 * * * *",
         zoneId,
         sendTo = workerRef,
-        message = PrintMessage(s"run job: ${counter}")
+        message = PrintMessage("run job")
       ),
-      ctx.messageAdapter[JobSchedulerProtocol.AddJobReply](ref => WrappedAddJobReply(ref))
+      ctx.messageAdapter[JobSchedulerProtocol.AddJobReply](WrappedAddJobReply(_))
     )
 
     Behaviors.receiveMessagePartial[Command] { case WrappedAddJobReply(AddJobSucceeded) =>
-      counter += 1
       Behaviors.same
     }
   }

--- a/example/src/main/scala/com/github/j5ik2o/chronos/example/AkkaActorMain.scala
+++ b/example/src/main/scala/com/github/j5ik2o/chronos/example/AkkaActorMain.scala
@@ -3,8 +3,7 @@ package com.github.j5ik2o.chronos.example
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ ActorSystem, Behavior }
 import com.github.j5ik2o.chronos.akka.JobSchedulerProtocol.AddJobSucceeded
-import com.github.j5ik2o.chronos.akka.{ JobSchedulerActor, JobSchedulerProtocol }
-import com.github.j5ik2o.chronos.core.Job
+import com.github.j5ik2o.chronos.akka.{ CborSerializable, Job, JobSchedulerActor, JobSchedulerProtocol }
 
 import java.time.ZoneId
 import java.util.UUID
@@ -12,15 +11,28 @@ import scala.concurrent.duration._
 
 object AkkaActorMain extends App {
 
-  val system: ActorSystem[Command] = ActorSystem(apply, "job-scheduler-actor-main")
+  sealed trait AppMessage extends CborSerializable
+  case class PrintMessage(text: String) extends AppMessage
 
   sealed trait Command
   case class WrappedAddJobReply(reply: JobSchedulerProtocol.AddJobReply) extends Command
+  case class WorkerMessage(msg: AppMessage)                               extends Command
+
+  val system: ActorSystem[Command] = ActorSystem(apply, "job-scheduler-actor-main")
 
   def apply: Behavior[Command] = Behaviors.setup[Command] { ctx =>
     val zoneId  = ZoneId.systemDefault()
     var counter = 0
     val id      = UUID.randomUUID()
+
+    val workerRef = ctx.spawn(
+      Behaviors.receiveMessage[AppMessage] {
+        case PrintMessage(text) =>
+          println(text)
+          Behaviors.same
+      },
+      "worker"
+    )
 
     val jobSchedulerActorRef = ctx.spawn(JobSchedulerActor(id, Some(500.millis)), "job-scheduler-actor")
 
@@ -30,14 +42,14 @@ object AkkaActorMain extends App {
         id = UUID.randomUUID(),
         cronExpression = "*/1 * * * *",
         zoneId,
-        run = { () =>
-          println(s"run job: $counter")
-          counter += 1
-        }
+        sendTo = workerRef,
+        message = PrintMessage(s"run job: ${counter}")
       ),
       ctx.messageAdapter[JobSchedulerProtocol.AddJobReply](ref => WrappedAddJobReply(ref))
     )
+
     Behaviors.receiveMessagePartial[Command] { case WrappedAddJobReply(AddJobSucceeded) =>
+      counter += 1
       Behaviors.same
     }
   }

--- a/pekko-actor/src/main/scala/com/github/j5ik2o/chronos/pekko/JobActor.scala
+++ b/pekko-actor/src/main/scala/com/github/j5ik2o/chronos/pekko/JobActor.scala
@@ -1,21 +1,36 @@
 package com.github.j5ik2o.chronos.pekko
 
-import org.apache.pekko.actor.typed.Behavior
+import org.apache.pekko.actor.typed.{ ActorRef, Behavior }
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
-import com.github.j5ik2o.chronos.core.Job
+import com.fasterxml.jackson.annotation.{ JsonIgnore, JsonTypeInfo }
+import com.github.j5ik2o.cron.CronSchedule
 
-import java.time.{ Duration, Instant }
+import java.time.{ Duration, Instant, ZoneId }
+import java.util.UUID
+import scala.concurrent.duration._
+
+case class Job[CMD](
+    id: UUID,
+    cronExpression: String,
+    zoneId: ZoneId,
+    limitMissedRuns: Int = 5,
+    tickInterval: FiniteDuration = 1.minutes,
+    sendTo: ActorRef[CMD],
+    @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS) message: CMD
+) extends CborSerializable {
+  @JsonIgnore private[chronos] lazy val schedule: CronSchedule = CronSchedule(cronExpression, zoneId)
+  @JsonIgnore private[chronos] def dispatch(): Unit             = sendTo ! message
+}
 
 object JobProtocol {
   sealed trait Command
   case object Tick extends Command
-  case object Run extends Command
-
+  case object Run  extends Command
 }
 
 object JobActor {
 
-  private def started(job: Job, clock: () => Instant)(
+  private def started(job: Job[_], clock: () => Instant)(
       lastTick: Option[Instant]
   ): Behavior[JobProtocol.Command] = {
     Behaviors.setup[JobProtocol.Command] { _ =>
@@ -23,13 +38,13 @@ object JobActor {
         case JobProtocol.Tick =>
           Behaviors.same
         case JobProtocol.Run =>
-          job.run()
+          job.dispatch()
           notStarted(job, clock)(lastTick)
       }
     }
   }
 
-  private def notStarted(job: Job, clock: () => Instant)(
+  private def notStarted(job: Job[_], clock: () => Instant)(
       lastTick: Option[Instant]
   ): Behavior[JobProtocol.Command] = {
     Behaviors.setup { ctx =>
@@ -62,7 +77,7 @@ object JobActor {
   }
 
   def apply(
-      job: Job,
+      job: Job[_],
       clock: () => Instant = () => Instant.now()
   ): Behavior[JobProtocol.Command] = {
     notStarted(job, clock)(None)

--- a/pekko-actor/src/main/scala/com/github/j5ik2o/chronos/pekko/JobActor.scala
+++ b/pekko-actor/src/main/scala/com/github/j5ik2o/chronos/pekko/JobActor.scala
@@ -19,13 +19,13 @@ case class Job[CMD](
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS) message: CMD
 ) extends CborSerializable {
   @JsonIgnore private[chronos] lazy val schedule: CronSchedule = CronSchedule(cronExpression, zoneId)
-  @JsonIgnore private[chronos] def dispatch(): Unit             = sendTo ! message
+  @JsonIgnore private[chronos] def dispatch(): Unit            = sendTo ! message
 }
 
 object JobProtocol {
   sealed trait Command
   case object Tick extends Command
-  case object Run  extends Command
+  case object Run extends Command
 }
 
 object JobActor {

--- a/pekko-actor/src/main/scala/com/github/j5ik2o/chronos/pekko/JobSchedulerActor.scala
+++ b/pekko-actor/src/main/scala/com/github/j5ik2o/chronos/pekko/JobSchedulerActor.scala
@@ -2,7 +2,6 @@ package com.github.j5ik2o.chronos.pekko
 
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
 import org.apache.pekko.actor.typed.{ ActorRef, Behavior }
-import com.github.j5ik2o.chronos.core.Job
 
 import java.time.Instant
 import java.util.UUID
@@ -10,46 +9,52 @@ import scala.concurrent.duration._
 
 object JobSchedulerProtocol {
   sealed trait Command
-  case class AddJob(schedulerId: UUID, job: Job, replyTo: ActorRef[AddJobReply]) extends Command
+  case class AddJob(schedulerId: UUID, job: Job[_], replyTo: ActorRef[AddJobReply]) extends Command
   sealed trait AddJobReply
-  case object AddJobSucceeded extends AddJobReply
-  case class AddJobFailed(ex: Throwable) extends AddJobReply
+  case object AddJobSucceeded                       extends AddJobReply
+  case class AddJobFailed(ex: Throwable)            extends AddJobReply
 
   case class RemoveJob(schedulerId: UUID, jobId: UUID, replyTo: ActorRef[RemoveJobReply]) extends Command
   sealed trait RemoveJobReply
-  case object RemoveJobSucceeded extends RemoveJobReply
-  case class RemoveJobFailed(ex: Throwable) extends RemoveJobReply
+  case object RemoveJobSucceeded                    extends RemoveJobReply
+  case class RemoveJobFailed(ex: Throwable)         extends RemoveJobReply
 
-  case class Tick(schedulerId: UUID) extends Command
-  case class Shutdown(schedulerId: UUID, replyTo: ActorRef[ShutdownCompleted.type]) extends Command
-  case object ShutdownCompleted extends Command
+  case class GetJobs(schedulerId: UUID, replyTo: ActorRef[GetJobsReply]) extends Command
+  sealed trait GetJobsReply
+  case class GetJobsResponse(jobs: Seq[Job[_]])     extends GetJobsReply
+
+  case class Tick(schedulerId: UUID)                                                      extends Command
+  case class Shutdown(schedulerId: UUID, replyTo: ActorRef[ShutdownCompleted.type])       extends Command
+  case object ShutdownCompleted                     extends Command
 }
 
 object JobSchedulerActor {
 
   private def running(
       schedulerId: UUID,
-      jobRefs: Map[UUID, ActorRef[JobProtocol.Command]],
+      jobs: Map[UUID, (Job[_], ActorRef[JobProtocol.Command])],
       clock: () => Instant
   ): Behavior[JobSchedulerProtocol.Command] = {
     Behaviors.setup { ctx =>
       Behaviors.receiveMessagePartial {
         case JobSchedulerProtocol.AddJob(sid, job, replyTo) if schedulerId == sid =>
-          val jobRef     = ctx.spawn(JobActor(job, clock), job.id.toString)
-          val newJobRefs = jobRefs + (job.id -> jobRef)
+          val jobRef  = ctx.spawn(JobActor(job, clock), job.id.toString)
+          val newJobs = jobs + (job.id -> (job, jobRef))
           replyTo ! JobSchedulerProtocol.AddJobSucceeded
-          running(schedulerId, newJobRefs, clock)
+          running(schedulerId, newJobs, clock)
         case JobSchedulerProtocol.RemoveJob(sid, jobId, replyTo) if schedulerId == sid =>
-          val jobRef = jobRefs.get(jobId)
-          jobRef.foreach(ref => ctx.stop(ref))
-          val newJobRefs = jobRefs - jobId
+          jobs.get(jobId).foreach { case (_, ref) => ctx.stop(ref) }
+          val newJobs = jobs - jobId
           replyTo ! JobSchedulerProtocol.RemoveJobSucceeded
-          running(schedulerId, newJobRefs, clock)
+          running(schedulerId, newJobs, clock)
+        case JobSchedulerProtocol.GetJobs(sid, replyTo) if schedulerId == sid =>
+          replyTo ! JobSchedulerProtocol.GetJobsResponse(jobs.values.map(_._1).toSeq)
+          Behaviors.same
         case JobSchedulerProtocol.Shutdown(sid, replyTo) if schedulerId == sid =>
           replyTo ! JobSchedulerProtocol.ShutdownCompleted
           Behaviors.stopped
         case JobSchedulerProtocol.Tick(sid) if schedulerId == sid =>
-          jobRefs.foreach { case (_, jobRef) =>
+          jobs.foreach { case (_, (_, jobRef)) =>
             jobRef ! JobProtocol.Tick
           }
           Behaviors.same

--- a/pekko-actor/src/main/scala/com/github/j5ik2o/chronos/pekko/JobSchedulerActor.scala
+++ b/pekko-actor/src/main/scala/com/github/j5ik2o/chronos/pekko/JobSchedulerActor.scala
@@ -11,21 +11,21 @@ object JobSchedulerProtocol {
   sealed trait Command
   case class AddJob(schedulerId: UUID, job: Job[_], replyTo: ActorRef[AddJobReply]) extends Command
   sealed trait AddJobReply
-  case object AddJobSucceeded                       extends AddJobReply
-  case class AddJobFailed(ex: Throwable)            extends AddJobReply
+  case object AddJobSucceeded extends AddJobReply
+  case class AddJobFailed(ex: Throwable) extends AddJobReply
 
   case class RemoveJob(schedulerId: UUID, jobId: UUID, replyTo: ActorRef[RemoveJobReply]) extends Command
   sealed trait RemoveJobReply
-  case object RemoveJobSucceeded                    extends RemoveJobReply
-  case class RemoveJobFailed(ex: Throwable)         extends RemoveJobReply
+  case object RemoveJobSucceeded extends RemoveJobReply
+  case class RemoveJobFailed(ex: Throwable) extends RemoveJobReply
 
   case class GetJobs(schedulerId: UUID, replyTo: ActorRef[GetJobsReply]) extends Command
   sealed trait GetJobsReply
-  case class GetJobsResponse(jobs: Seq[Job[_]])     extends GetJobsReply
+  case class GetJobsResponse(jobs: Seq[Job[_]]) extends GetJobsReply
 
-  case class Tick(schedulerId: UUID)                                                      extends Command
-  case class Shutdown(schedulerId: UUID, replyTo: ActorRef[ShutdownCompleted.type])       extends Command
-  case object ShutdownCompleted                     extends Command
+  case class Tick(schedulerId: UUID) extends Command
+  case class Shutdown(schedulerId: UUID, replyTo: ActorRef[ShutdownCompleted.type]) extends Command
+  case object ShutdownCompleted extends Command
 }
 
 object JobSchedulerActor {

--- a/pekko-actor/src/main/scala/com/github/j5ik2o/chronos/pekko/PersistentJobSchedulerActor.scala
+++ b/pekko-actor/src/main/scala/com/github/j5ik2o/chronos/pekko/PersistentJobSchedulerActor.scala
@@ -12,15 +12,15 @@ import scala.concurrent.duration.FiniteDuration
 
 object JobSchedulerEvents {
   sealed trait Event extends CborSerializable
-  case class JobAdded(schedulerId: UUID, job: Job[_], replyTo: ActorRef[AddJobReply])    extends Event
+  case class JobAdded(schedulerId: UUID, job: Job[_], replyTo: ActorRef[AddJobReply]) extends Event
   case class JobRemoved(schedulerId: UUID, jobID: UUID, replyTo: ActorRef[RemoveJobReply]) extends Event
 }
 
 object PersistentJobSchedulerActor {
 
   sealed trait State
-  case object EmptyState                                              extends State
-  case class JustState(schedulerId: UUID, jobs: Map[UUID, Job[_]])   extends State
+  case object EmptyState extends State
+  case class JustState(schedulerId: UUID, jobs: Map[UUID, Job[_]]) extends State
 
   def apply(
       id: UUID,

--- a/pekko-actor/src/main/scala/com/github/j5ik2o/chronos/pekko/PersistentJobSchedulerActor.scala
+++ b/pekko-actor/src/main/scala/com/github/j5ik2o/chronos/pekko/PersistentJobSchedulerActor.scala
@@ -5,7 +5,6 @@ import org.apache.pekko.actor.typed.{ ActorRef, Behavior }
 import org.apache.pekko.persistence.typed.PersistenceId
 import org.apache.pekko.persistence.typed.scaladsl.{ Effect, EventSourcedBehavior }
 import com.github.j5ik2o.chronos.pekko.JobSchedulerProtocol.{ AddJobReply, RemoveJobReply }
-import com.github.j5ik2o.chronos.core.Job
 
 import java.time.Instant
 import java.util.UUID
@@ -13,15 +12,15 @@ import scala.concurrent.duration.FiniteDuration
 
 object JobSchedulerEvents {
   sealed trait Event extends CborSerializable
-  case class JobAdded(schedulerId: UUID, job: Job, replyTo: ActorRef[AddJobReply]) extends Event
+  case class JobAdded(schedulerId: UUID, job: Job[_], replyTo: ActorRef[AddJobReply])    extends Event
   case class JobRemoved(schedulerId: UUID, jobID: UUID, replyTo: ActorRef[RemoveJobReply]) extends Event
 }
 
 object PersistentJobSchedulerActor {
 
   sealed trait State
-  case object EmptyState extends State
-  case class JustState(schedulerId: UUID, jobs: Map[UUID, Job]) extends State
+  case object EmptyState                                              extends State
+  case class JustState(schedulerId: UUID, jobs: Map[UUID, Job[_]])   extends State
 
   def apply(
       id: UUID,
@@ -51,6 +50,8 @@ object PersistentJobSchedulerActor {
                 }
             case (EmptyState, JobSchedulerProtocol.Tick(_)) =>
               Effect.noReply
+            case (EmptyState, JobSchedulerProtocol.GetJobs(_, replyTo)) =>
+              Effect.reply(replyTo)(JobSchedulerProtocol.GetJobsResponse(Seq.empty))
             case (JustState(schedulerId, _), JobSchedulerProtocol.AddJob(sid, job, replyTo)) if schedulerId == sid =>
               Effect
                 .persist(JobSchedulerEvents.JobAdded(sid, job, replyTo)).thenReply(replyTo) { _ =>
@@ -66,6 +67,8 @@ object PersistentJobSchedulerActor {
                 .thenReply(replyTo) { _ =>
                   JobSchedulerProtocol.RemoveJobSucceeded
                 }
+            case (JustState(schedulerId, jobs), JobSchedulerProtocol.GetJobs(sid, replyTo)) if schedulerId == sid =>
+              Effect.reply(replyTo)(JobSchedulerProtocol.GetJobsResponse(jobs.values.toSeq))
             case (JustState(schedulerId, _), JobSchedulerProtocol.Shutdown(sid, replyTo)) if schedulerId == sid =>
               Effect.stop().thenReply(replyTo) { _ =>
                 JobSchedulerProtocol.ShutdownCompleted
@@ -89,7 +92,6 @@ object PersistentJobSchedulerActor {
               JustState(schedulerId, jobs - jobId)
           }
         )
-
       }
     }
   }

--- a/pekko-actor/src/test/scala/com/github/j5ik2o/chronos/pekko/JobSchedulerActorSpec.scala
+++ b/pekko-actor/src/test/scala/com/github/j5ik2o/chronos/pekko/JobSchedulerActorSpec.scala
@@ -24,7 +24,7 @@ class JobSchedulerActorSpec extends AnyFunSuite {
     val jobSchedulerActorRef = testKit.spawn(JobSchedulerActor(id, clock = clock))
 
     val reply = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
-    val job = Job(
+    val job   = Job(
       id = UUID.randomUUID(),
       cronExpression = "*/1 * * * *",
       zoneId,
@@ -69,7 +69,7 @@ class JobSchedulerActorSpec extends AnyFunSuite {
     val jobSchedulerActorRef = testKit.spawn(JobSchedulerActor(id, clock = clock))
 
     val reply = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
-    val job = Job(
+    val job   = Job(
       id = UUID.randomUUID(),
       cronExpression = "*/1 * * * *",
       zoneId,
@@ -128,7 +128,7 @@ class JobSchedulerActorSpec extends AnyFunSuite {
     val jobSchedulerActorRef = testKit.spawn(JobSchedulerActor(id, clock = clock))
 
     val reply = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
-    val job = Job(
+    val job   = Job(
       id = UUID.randomUUID(),
       cronExpression = "*/1 * * * *",
       zoneId,

--- a/pekko-actor/src/test/scala/com/github/j5ik2o/chronos/pekko/JobSchedulerActorSpec.scala
+++ b/pekko-actor/src/test/scala/com/github/j5ik2o/chronos/pekko/JobSchedulerActorSpec.scala
@@ -1,7 +1,6 @@
 package com.github.j5ik2o.chronos.pekko
 
 import org.apache.pekko.actor.testkit.typed.scaladsl.ActorTestKit
-import com.github.j5ik2o.chronos.core.Job
 import org.scalatest.funsuite.AnyFunSuite
 
 import java.time.{ Instant, ZoneId }
@@ -13,101 +12,129 @@ class JobSchedulerActorSpec extends AnyFunSuite {
 
   val testKit: ActorTestKit = ActorTestKit()
 
+  sealed trait TestMessage extends CborSerializable
+  case object DoWork extends TestMessage
+
   test("job fires only on cron boundary") {
     val zoneId               = ZoneId.of("UTC")
     val mockTime             = new AtomicReference[Instant](Instant.parse("2024-01-01T12:00:00Z"))
     val clock: () => Instant = () => mockTime.get()
-    var counter              = 0
     val id                   = UUID.randomUUID()
+    val probe                = testKit.createTestProbe[TestMessage]()
     val jobSchedulerActorRef = testKit.spawn(JobSchedulerActor(id, clock = clock))
 
     val reply = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
-    val job   = Job(
+    val job = Job(
       id = UUID.randomUUID(),
       cronExpression = "*/1 * * * *",
       zoneId,
       tickInterval = 500.millis,
-      run = { () => counter += 1 }
+      sendTo = probe.ref,
+      message = DoWork
     )
     jobSchedulerActorRef ! JobSchedulerProtocol.AddJob(id, job, reply.ref)
     reply.expectMessage(JobSchedulerProtocol.AddJobSucceeded)
 
     // Tick 1: initialize lastTick
     jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-    Thread.sleep(200)
-    assert(counter == 0)
+    probe.expectNoMessage(200.millis)
 
     // Tick 2: tickInterval elapsed, but no cron period passed
     mockTime.set(Instant.parse("2024-01-01T12:00:00.600Z"))
     jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-    Thread.sleep(200)
-    assert(counter == 0)
+    probe.expectNoMessage(200.millis)
 
     // Tick 3: past cron boundary (12:01:00)
     mockTime.set(Instant.parse("2024-01-01T12:01:00.100Z"))
     jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-    Thread.sleep(200)
-    assert(counter == 1)
+    probe.expectMessage(DoWork)
 
     // Tick 4: not yet next cron boundary
     mockTime.set(Instant.parse("2024-01-01T12:01:00.700Z"))
     jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-    Thread.sleep(200)
-    assert(counter == 1)
+    probe.expectNoMessage(200.millis)
 
-    // Tick 5: past next cron boundary (12:02:00.100)
+    // Tick 5: past next cron boundary
     mockTime.set(Instant.parse("2024-01-01T12:02:00.200Z"))
     jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-    Thread.sleep(200)
-    assert(counter == 2)
+    probe.expectMessage(DoWork)
   }
 
   test("job does not fire when limitMissedRuns exceeded") {
     val zoneId               = ZoneId.of("UTC")
     val mockTime             = new AtomicReference[Instant](Instant.parse("2024-01-01T12:00:00Z"))
     val clock: () => Instant = () => mockTime.get()
-    var counter              = 0
     val id                   = UUID.randomUUID()
+    val probe                = testKit.createTestProbe[TestMessage]()
     val jobSchedulerActorRef = testKit.spawn(JobSchedulerActor(id, clock = clock))
 
     val reply = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
-    val job   = Job(
+    val job = Job(
       id = UUID.randomUUID(),
       cronExpression = "*/1 * * * *",
       zoneId,
       limitMissedRuns = 3,
       tickInterval = 500.millis,
-      run = { () => counter += 1 }
+      sendTo = probe.ref,
+      message = DoWork
     )
     jobSchedulerActorRef ! JobSchedulerProtocol.AddJob(id, job, reply.ref)
     reply.expectMessage(JobSchedulerProtocol.AddJobSucceeded)
 
     // Tick 1: initialize
     jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-    Thread.sleep(200)
+    probe.expectNoMessage(200.millis)
 
     // Tick 2: jump 10 minutes ahead (missed more than 3 runs)
     mockTime.set(Instant.parse("2024-01-01T12:10:00.100Z"))
     jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-    Thread.sleep(200)
-    assert(counter == 0)
+    probe.expectNoMessage(200.millis)
+  }
+
+  test("GetJobs returns added jobs") {
+    val zoneId               = ZoneId.of("UTC")
+    val id                   = UUID.randomUUID()
+    val probe                = testKit.createTestProbe[TestMessage]()
+    val jobSchedulerActorRef = testKit.spawn(JobSchedulerActor(id))
+    val addReply             = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
+    val getReply             = testKit.createTestProbe[JobSchedulerProtocol.GetJobsReply]()
+
+    val job = Job(
+      id = UUID.randomUUID(),
+      cronExpression = "*/1 * * * *",
+      zoneId,
+      tickInterval = 500.millis,
+      sendTo = probe.ref,
+      message = DoWork
+    )
+
+    jobSchedulerActorRef ! JobSchedulerProtocol.GetJobs(id, getReply.ref)
+    getReply.expectMessage(JobSchedulerProtocol.GetJobsResponse(Seq.empty))
+
+    jobSchedulerActorRef ! JobSchedulerProtocol.AddJob(id, job, addReply.ref)
+    addReply.expectMessage(JobSchedulerProtocol.AddJobSucceeded)
+
+    jobSchedulerActorRef ! JobSchedulerProtocol.GetJobs(id, getReply.ref)
+    val response = getReply.expectMessageType[JobSchedulerProtocol.GetJobsResponse]
+    assert(response.jobs.map(_.id) == Seq(job.id))
   }
 
   test("rapid ticks do not cause errors") {
     val zoneId               = ZoneId.of("UTC")
     val mockTime             = new AtomicReference[Instant](Instant.parse("2024-01-01T12:00:00Z"))
     val clock: () => Instant = () => mockTime.get()
-    var counter              = 0
     val id                   = UUID.randomUUID()
+    val probe                = testKit.createTestProbe[TestMessage]()
     val jobSchedulerActorRef = testKit.spawn(JobSchedulerActor(id, clock = clock))
 
     val reply = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
-    val job   = Job(
+    val job = Job(
       id = UUID.randomUUID(),
       cronExpression = "*/1 * * * *",
       zoneId,
       tickInterval = 500.millis,
-      run = { () => counter += 1 }
+      sendTo = probe.ref,
+      message = DoWork
     )
     jobSchedulerActorRef ! JobSchedulerProtocol.AddJob(id, job, reply.ref)
     reply.expectMessage(JobSchedulerProtocol.AddJobSucceeded)
@@ -116,7 +143,6 @@ class JobSchedulerActorSpec extends AnyFunSuite {
     for (_ <- 1 to 10) {
       jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
     }
-    Thread.sleep(200)
-    assert(counter == 0)
+    probe.expectNoMessage(200.millis)
   }
 }

--- a/pekko-actor/src/test/scala/com/github/j5ik2o/chronos/pekko/PersistentJobSchedulerActorSpec.scala
+++ b/pekko-actor/src/test/scala/com/github/j5ik2o/chronos/pekko/PersistentJobSchedulerActorSpec.scala
@@ -1,14 +1,13 @@
 package com.github.j5ik2o.chronos.pekko
 
 import org.apache.pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
-import com.github.j5ik2o.chronos.core.Job
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.freespec.AnyFreeSpecLike
 
 import java.time.{ Instant, ZoneId }
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicReference
-import scala.concurrent.duration.DurationInt
+import scala.concurrent.duration._
 
 object PersistentJobSchedulerActorSpec {
   val config: Config = ConfigFactory.parseString(s"""
@@ -26,13 +25,16 @@ class PersistentJobSchedulerActorSpec
     extends ScalaTestWithActorTestKit(PersistentJobSchedulerActorSpec.config)
     with AnyFreeSpecLike {
 
+  sealed trait TestMessage extends CborSerializable
+  case object DoWork extends TestMessage
+
   "PersistentJobSchedulerActor" - {
     "job fires only on cron boundary" in {
       val zoneId               = ZoneId.of("UTC")
       val mockTime             = new AtomicReference[Instant](Instant.parse("2024-01-01T12:00:00Z"))
       val clock: () => Instant = () => mockTime.get()
-      var counter              = 0
       val id                   = UUID.randomUUID()
+      val probe                = testKit.createTestProbe[TestMessage]()
 
       val jobSchedulerActorRef = testKit.spawn(PersistentJobSchedulerActor(id, clock = clock))
       val reply                = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
@@ -42,44 +44,41 @@ class PersistentJobSchedulerActorSpec
         cronExpression = "*/1 * * * *",
         zoneId,
         tickInterval = 500.millis,
-        run = { () => counter += 1 }
+        sendTo = probe.ref,
+        message = DoWork
       )
       jobSchedulerActorRef ! JobSchedulerProtocol.AddJob(id, job, reply.ref)
       reply.expectMessage(JobSchedulerProtocol.AddJobSucceeded)
 
       // Tick 1: initialize lastTick
       jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-      Thread.sleep(200)
-      assert(counter == 0)
+      probe.expectNoMessage(200.millis)
 
       // Tick 2: tickInterval elapsed, but no cron period passed
       mockTime.set(Instant.parse("2024-01-01T12:00:00.600Z"))
       jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-      Thread.sleep(200)
-      assert(counter == 0)
+      probe.expectNoMessage(200.millis)
 
       // Tick 3: past cron boundary
       mockTime.set(Instant.parse("2024-01-01T12:01:00.100Z"))
       jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-      Thread.sleep(200)
-      assert(counter == 1)
+      probe.expectMessage(DoWork)
 
       // Tick 4: not yet next cron boundary
       mockTime.set(Instant.parse("2024-01-01T12:01:00.700Z"))
       jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-      Thread.sleep(200)
-      assert(counter == 1)
+      probe.expectNoMessage(200.millis)
 
       // Tick 5: past next cron boundary
       mockTime.set(Instant.parse("2024-01-01T12:02:00.200Z"))
       jobSchedulerActorRef ! JobSchedulerProtocol.Tick(id)
-      Thread.sleep(200)
-      assert(counter == 2)
+      probe.expectMessage(DoWork)
     }
 
     "add multiple jobs in JustState" in {
       val zoneId = ZoneId.systemDefault()
       val id     = UUID.randomUUID()
+      val probe  = testKit.createTestProbe[TestMessage]()
 
       val jobSchedulerActorRef = testKit.spawn(PersistentJobSchedulerActor(id))
       val reply1               = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
@@ -90,14 +89,16 @@ class PersistentJobSchedulerActorSpec
         cronExpression = "*/1 * * * *",
         zoneId,
         tickInterval = 500.millis,
-        run = { () => () }
+        sendTo = probe.ref,
+        message = DoWork
       )
       val job2 = Job(
         id = UUID.randomUUID(),
         cronExpression = "*/1 * * * *",
         zoneId,
         tickInterval = 500.millis,
-        run = { () => () }
+        sendTo = probe.ref,
+        message = DoWork
       )
 
       jobSchedulerActorRef ! JobSchedulerProtocol.AddJob(id, job1, reply1.ref)
@@ -110,6 +111,7 @@ class PersistentJobSchedulerActorSpec
     "remove job in JustState" in {
       val zoneId = ZoneId.systemDefault()
       val id     = UUID.randomUUID()
+      val probe  = testKit.createTestProbe[TestMessage]()
 
       val jobSchedulerActorRef = testKit.spawn(PersistentJobSchedulerActor(id))
       val addReply             = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
@@ -120,7 +122,8 @@ class PersistentJobSchedulerActorSpec
         cronExpression = "*/1 * * * *",
         zoneId,
         tickInterval = 500.millis,
-        run = { () => () }
+        sendTo = probe.ref,
+        message = DoWork
       )
 
       jobSchedulerActorRef ! JobSchedulerProtocol.AddJob(id, job, addReply.ref)
@@ -130,9 +133,44 @@ class PersistentJobSchedulerActorSpec
       removeReply.expectMessage(JobSchedulerProtocol.RemoveJobSucceeded)
     }
 
+    "GetJobs returns empty in EmptyState" in {
+      val id                   = UUID.randomUUID()
+      val jobSchedulerActorRef = testKit.spawn(PersistentJobSchedulerActor(id))
+      val getReply             = testKit.createTestProbe[JobSchedulerProtocol.GetJobsReply]()
+
+      jobSchedulerActorRef ! JobSchedulerProtocol.GetJobs(id, getReply.ref)
+      getReply.expectMessage(JobSchedulerProtocol.GetJobsResponse(Seq.empty))
+    }
+
+    "GetJobs returns added jobs in JustState" in {
+      val zoneId               = ZoneId.systemDefault()
+      val id                   = UUID.randomUUID()
+      val probe                = testKit.createTestProbe[TestMessage]()
+      val jobSchedulerActorRef = testKit.spawn(PersistentJobSchedulerActor(id))
+      val addReply             = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
+      val getReply             = testKit.createTestProbe[JobSchedulerProtocol.GetJobsReply]()
+
+      val job = Job(
+        id = UUID.randomUUID(),
+        cronExpression = "*/1 * * * *",
+        zoneId,
+        tickInterval = 500.millis,
+        sendTo = probe.ref,
+        message = DoWork
+      )
+
+      jobSchedulerActorRef ! JobSchedulerProtocol.AddJob(id, job, addReply.ref)
+      addReply.expectMessage(JobSchedulerProtocol.AddJobSucceeded)
+
+      jobSchedulerActorRef ! JobSchedulerProtocol.GetJobs(id, getReply.ref)
+      val response = getReply.expectMessageType[JobSchedulerProtocol.GetJobsResponse]
+      assert(response.jobs.map(_.id) == Seq(job.id))
+    }
+
     "shutdown in JustState" in {
       val zoneId = ZoneId.systemDefault()
       val id     = UUID.randomUUID()
+      val probe  = testKit.createTestProbe[TestMessage]()
 
       val jobSchedulerActorRef = testKit.spawn(PersistentJobSchedulerActor(id))
       val addReply             = testKit.createTestProbe[JobSchedulerProtocol.AddJobReply]()
@@ -143,7 +181,8 @@ class PersistentJobSchedulerActorSpec
         cronExpression = "*/1 * * * *",
         zoneId,
         tickInterval = 500.millis,
-        run = { () => () }
+        sendTo = probe.ref,
+        message = DoWork
       )
 
       jobSchedulerActorRef ! JobSchedulerProtocol.AddJob(id, job, addReply.ref)


### PR DESCRIPTION
## Summary

- Replace non-serializable `run: () => Unit` with `sendTo: ActorRef[CMD]` and `message: CMD` on `Job[CMD]`, fixing NPE on `PersistentJobSchedulerActor` restart (transient field becomes null after CBOR deserialization)
- Add `@JsonIgnore` to `schedule: CronSchedule` lazy val and `dispatch()` method to prevent Jackson from attempting to serialize non-serializable types
- Add `@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)` to `message: CMD` for polymorphic deserialization
- Add `GetJobs` API to query currently scheduled jobs
- Rewrite tests using `TestProbe` + message assertions instead of mutable counter + `Thread.sleep`
- Update `AkkaActorMain` example to use the new `Job[CMD]` API

## Test plan

- [x] `sbt "akka-actor/test"` — 10 tests pass
- [x] `sbt "pekko-actor/test"` — 10 tests pass
- [x] `sbt "example/compile"` — compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the job execution/serialization model and the data persisted by `PersistentJobSchedulerActor`, which can affect restart behavior and compatibility with existing persisted events.
> 
> **Overview**
> Replaces `Job`’s non-serializable `run: () => Unit` callback with a typed, serializable message dispatch model (`sendTo: ActorRef[CMD]` + `message: CMD`) in both Akka and Pekko implementations, updating `JobActor` to call `dispatch()` and adding Jackson CBOR annotations to avoid serializing runtime-only fields.
> 
> Extends `JobSchedulerProtocol` with `GetJobs`/`GetJobsResponse` and updates both in-memory and persistent schedulers to track job definitions and return the currently scheduled jobs.
> 
> Updates the example and rewrites scheduler specs to use `TestProbe` message assertions (and adds coverage for `GetJobs`) instead of mutable counters and `Thread.sleep`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc5039c9dd808457ee6a137ec8c571c50365fe66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->